### PR TITLE
Adjust template based on open source template

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -19,7 +19,7 @@ about: Create a report to help us improve
 ## ℹ️ Environment
 - **Device**: <!-- e.g. Pixel 5 -->
 - **OS**: <!-- e.g. 9.0.0 -->
-- **Library version**: <!-- e.g. Sentinel 1.3.0). -->
+- **Library version**: <!-- e.g. 1.3.0). -->
 
 ## 💣 Steps to reproduce
 <!-- How we can reproduce the behavior: -->

--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -19,7 +19,7 @@ about: Create a report to help us improve
 ## Environment
 - **Device**: <!-- e.g. Pixel 5 -->
 - **OS**: <!-- e.g. 9.0.0 -->
-- **Software Information**: <!-- Add software information (e.g. name, version, build number, etc.). -->
+- **Library version**: <!-- e.g. Sentinel 1.3.0). -->
 
 ## Steps to reproduce
 <!-- How we can reproduce the behavior: -->

--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -13,26 +13,26 @@ about: Create a report to help us improve
 
 ---
 
-## Description
+## 📖 Description
 <!-- A clear and concise description of what the bug is. -->
 
-## Environment
+## ℹ️ Environment
 - **Device**: <!-- e.g. Pixel 5 -->
 - **OS**: <!-- e.g. 9.0.0 -->
 - **Library version**: <!-- e.g. Sentinel 1.3.0). -->
 
-## Steps to reproduce
+## 💣 Steps to reproduce
 <!-- How we can reproduce the behavior: -->
 1. Go to '...'
 2. Click on '....'
 3. Scroll down to '....'
 4. See error
 
-## Expected behavior
+## 🔧 Expected behavior
 <!-- A clear and concise description of what you expected to happen. -->
 
-## Screenshots
+## 📷 Screenshots
 <!-- If applicable, add screenshots to help explain your problem. -->
 
-## Additional information
+## 📄 Additional information
 <!-- Add any other context about the problem here. -->

--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,7 +1,7 @@
 ---
 name: Bug report
 about: Create a report to help us improve
-title: ''
+title: 'Bug report: '
 labels: bug
 assignees: ''
 
@@ -13,26 +13,26 @@ about: Create a report to help us improve
 
 ---
 
-## :writing_hand: Describe the bug
+## Description
 <!-- A clear and concise description of what the bug is. -->
 
-## :bomb: Steps to reproduce
+## Environment
+- **Device**: <!-- e.g. Pixel 5 -->
+- **OS**: <!-- e.g. 9.0.0 -->
+- **Software Information**: <!-- Add software information (e.g. name, version, build number, etc.). -->
+
+## Steps to reproduce
 <!-- How we can reproduce the behavior: -->
 1. Go to '...'
 2. Click on '....'
 3. Scroll down to '....'
 4. See error
 
-## :wrench: Expected behavior
+## Expected behavior
 <!-- A clear and concise description of what you expected to happen. -->
 
-## :camera: Screenshots
+## Screenshots
 <!-- If applicable, add screenshots to help explain your problem. -->
 
-## :iphone: Tech info
- - Device: <!-- e.g. Pixel 5 -->
- - OS: <!-- e.g. 9.0.0 -->
- - Sentinel version: <!-- e.g. 1.0.1 -->
-
-## :page_facing_up: Additional context
+## Additional information
 <!-- Add any other context about the problem here. -->

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,31 +1,21 @@
 ---
 name: Feature request
-about: Suggest an idea for this project
-title: ''
+about: Propose a new feature or an idea for this project
+title: 'Feature request: '
 labels: enhancement
 assignees: ''
 
 ---
 
----
-name: Feature request
-about: Suggest an idea for this project
 
----
+## Feature description
+<!-- 
+    Add a description of what the the feature is, and what problem does it solve.
+    Try to include clear and concise information about the feature you're requesting.
+-->
 
-## :warning: Is your feature request related to a problem? Please describe
-<!-- A clear and concise description of what the problem is. Ex. I'm always frustrated when [...] -->
+## Additional information
 
-## :bulb: Describe the solution you'd like
-<!-- A clear and concise description of what you want to happen. -->
-
-## :bar_chart: Describe alternatives you've considered
-<!-- A clear and concise description of any alternative solutions or features you've considered. -->
-
-## :page_facing_up: Additional context
-<!-- Add any other context or screenshots about the feature request here. -->
-
-## :raising_hand: Do you want to develop this feature yourself?
-<!-- Put an `x` symbol into braces of desired choice. -->
-- [ ] Yes
-- [ ] No
+<!-- 
+    Add any other information or screenshots about the feature request here. 
+-->

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -19,3 +19,8 @@ assignees: ''
 <!-- 
     Add any other information or screenshots about the feature request here. 
 -->
+
+##  Describe alternatives you've considered
+<!-- 
+    Can you think of alternative approaches to achieve same goal?
+-->

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -8,19 +8,19 @@ assignees: ''
 ---
 
 
-## Feature description
+## 💡 Feature description
 <!-- 
     Add a description of what the the feature is, and what problem does it solve.
     Try to include clear and concise information about the feature you're requesting.
 -->
 
-## Additional information
+## ℹ️ Additional information
 
 <!-- 
     Add any other information or screenshots about the feature request here. 
 -->
 
-##  Describe alternatives you've considered
+## 🤔 Describe alternatives you've considered
 <!-- 
     Can you think of alternative approaches to achieve same goal?
 -->

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,20 +1,42 @@
-## :camera: Screenshots
-<!-- Show us what you've changed, we love images. -->
+## Summary
 
-## :page_facing_up: Context
-<!-- Why did you change something? Is there an issue to link here? Or an external link? -->
+<!-- 
+    Provide an overview of what this pull request aims to address or achieve.
 
-## :pencil: Changes
-<!-- Which code did you change? How? -->
+    Link any relevant issues that this pull request addresses or resolves, using the format "Fixes #issue_number". 
+-->
 
-## :paperclip: Related PR
-<!-- PR that blocks this one, or the ones blocked by this PR -->
+## Changes
 
-## :no_entry_sign: Breaking
-<!-- Is there something breaking the API? Any class or method signature changed? -->
+### Type
 
-## :hammer_and_wrench: How to test
-<!-- Is there a special case to test your changes? -->
+- [ ] **Feature**: This pull request introduces a new feature.
+- [ ] **Bug fix**: This pull request fixes a bug.
+- [ ] **Refactor**: This pull request refactors existing code.
+- [ ] **Documentation**: This pull request updates documentation.
+- [ ] **Other**: This pull request makes other changes.
 
-## :stopwatch: Next steps
-<!-- Do we have to plan something else after the merge? -->
+#### Additional information
+
+- [ ] This pull request introduces a **breaking change**.
+
+### Description
+
+<!-- 
+    Describe the specific changes made in this pull request, including any technical details or architectural decisions. 
+
+    If applicable, include additional information like screenshots, logs or other data that demonstrate the changes. 
+-->
+
+## Checklist
+
+- [ ] I have performed a self-review of my own code.
+- [ ] I have tested my changes, including edge cases.
+- [ ] I have added necessary tests for the changes introduced (if applicable).
+- [ ] I have updated the documentation to reflect my changes (if applicable).
+
+## Additional notes
+
+<!-- 
+    Add any additional comments, instructions, or insights about this pull request. 
+-->

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,74 @@
+# Code of conduct
+
+## Our pledge
+
+In the interest of fostering an open and welcoming environment, we as
+contributors and maintainers pledge to making participation in our project and
+our community a harassment-free experience for everyone, regardless of age, body
+size, disability, ethnicity, sex characteristics, gender identity and expression,
+level of experience, education, socio-economic status, nationality, personal
+appearance, race, religion, or sexual identity and orientation.
+
+## Our standards
+
+Examples of behavior that contributes to creating a positive environment
+include:
+
+* Using welcoming and inclusive language
+* Being respectful of differing viewpoints and experiences
+* Gracefully accepting constructive criticism
+* Focusing on what is best for the community
+* Showing empathy towards other community members
+
+Examples of unacceptable behavior by participants include:
+
+* The use of sexualized language or imagery and unwelcome sexual attention or
+ advances
+* Trolling, insulting/derogatory comments, and personal or political attacks
+* Public or private harassment
+* Publishing others' private information, such as a physical or electronic
+ address, without explicit permission
+* Other conduct which could reasonably be considered inappropriate in a
+ professional setting
+
+## Our responsibilities
+
+Project maintainers are responsible for clarifying the standards of acceptable
+behavior and are expected to take appropriate and fair corrective action in
+response to any instances of unacceptable behavior.
+
+Project maintainers have the right and responsibility to remove, edit, or
+reject comments, commits, code, wiki edits, issues, and other contributions
+that are not aligned to this Code of Conduct, or to ban temporarily or
+permanently any contributor for other behaviors that they deem inappropriate,
+threatening, offensive, or harmful.
+
+## Scope
+
+This Code of Conduct applies both within project spaces and in public spaces
+when an individual is representing the project or its community. Examples of
+representing a project or community include using an official project e-mail
+address, posting via an official social media account, or acting as an appointed
+representative at an online or offline event. Representation of a project may be
+further defined and clarified by project maintainers.
+
+## Enforcement
+
+Instances of abusive, harassing, or otherwise unacceptable behavior may be
+reported by contacting the project team at opensource@infinum.com. All
+complaints will be reviewed and investigated and will result in a response that
+is deemed necessary and appropriate to the circumstances. The project team is
+obligated to maintain confidentiality with regard to the reporter of an incident.
+Further details of specific enforcement policies may be posted separately.
+
+Project maintainers who do not follow or enforce the Code of Conduct in good
+faith may face temporary or permanent repercussions as determined by other
+members of the project's leadership.
+
+## Attribution
+
+This Code of Conduct is adapted from the [Contributor Covenant](https://www.contributor-covenant.org), version 1.4,
+available [here](https://www.contributor-covenant.org/version/1/4/code-of-conduct.html).
+
+For answers to common questions about this code of conduct, visit
+the [FAQ](https://www.contributor-covenant.org/faq) page.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,42 @@
+# Contributing guidelines
+
+Welcome to our project! We appreciate your interest in helping us improve it.
+
+## How can I contribute?
+
+There are multiple ways in which you can help us make this project even better.
+
+- Contributing code improvements or new features
+- Writing, updating, or fixing tests
+- Improving documentation, including inline comments, user manuals, and developer guides
+
+## Making changes
+
+To make changes to the project, please follow these steps:
+
+1. Fork the project repository.
+2. Create a new branch for your changes, based on the project's main branch.
+3. Make your changes. Ensure you've followed the coding style and standards.
+4. Test your changes thoroughly, ensuring all existing tests pass and new tests cover your changes where appropriate.
+5. Commit your changes with a clear and descriptive commit message.
+6. Push your changes to your fork.
+7. Create a pull request to the project's main branch.
+
+Once we check everything, we will merge the changes into the main branch and include it in the next release.
+
+## Guidelines for pull requests
+
+When submitting a pull request, please ensure that:
+
+- Your code is properly tested
+- Your code adheres to the project's coding standards and style guidelines
+- Your commit message is clear and descriptive
+- Your pull request includes a description of the changes you have made and why you have made them
+
+## Code of conduct
+
+We want to ensure a welcoming environment for everyone. With that in mind, all contributors are expected to follow our [code of conduct](/CODE_OF_CONDUCT.md).
+
+## License
+
+By submitting a pull request you agree to release that code under the project's [license](/LICENSE).

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,201 @@
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright [yyyy] [name of copyright owner]
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/README.md
+++ b/README.md
@@ -83,23 +83,23 @@ Setup instruction: Follow the steps from the SETUP.md file.
 
 ## Contributing
 
-Feedback and code contributions are very much welcome. Just make a pull request with a short
-description of your changes. By making contributions to this project you give permission for your
-code to be used under the same [license](LICENSE).
+We believe that the community can help us improve and build better a product.
+Please refer to our [contributing guide](CONTRIBUTING.md) to learn about the types of contributions we accept and the process for submitting them.
 
-// Add any other info specific to contributing to this library (e.g., if you have a sample app to
-help with development) //
+To ensure that our community remains respectful and professional, we defined a [code of conduct](CODE_OF_CONDUCT.md) <!-- and [coding standards](<link>) --> that we expect all contributors to follow.
+
+We appreciate your interest and look forward to your contributions.
 
 ## License
 
-```
-Copyright 2021 Infinum
+```text
+Copyright 2024 Infinum
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-   http://www.apache.org/licenses/LICENSE-2.0
+    http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,

--- a/README.md
+++ b/README.md
@@ -1,46 +1,95 @@
+```text
+Setup instruction: Follow the steps from the SETUP.md file.
+```
 
 // Maven central / CI build badges / links (Github pages, wiki, etc.) //
 
-### <img align="left" src="logo.svg" width="48">
 # // Library name //
 
-// Library logo (left wrap with title) //
+<!--
+    This is the logo/image area for the project.
+    Add a project logo or image (if applicable) to this part of the file.
 
-// OPTIONAL: A single image/screenshot/GIF descriptive of the main library function. You can stitch multiple images so they fit better horizontally if there are more things to show. //
+    Try to make it visually appealing and relevant to the project.
+    Check the *Credits* section as an example for a centered image.
+-->
 
-// Introduce the library with max 3-4 paragraphs describing what the library is and what is it used for. Try to use bulletpoints to highlight main features of the lib. //
+<!--
+    This is the status area for the project.
+    Add project badges (if needed) to this part of the file.
+-->
 
-// OPTIONAL: If there are any additional modules/plugins, list and describe them here //
+## Description
 
-## Getting started
+<!--
+    Provide a detailed explanation of the project, its purpose, and its goals.
+    Include any relevant background information, such as the problem the project solves,
+    the target audience, and how the project differs from other similar projects.
+-->
 
-// Groovy and KotlinDSL snippets for including the library (and its modules) //
+## Table of contents
 
-### Usage
-
-// Explain the basic code setup and usage of the library with relevant code snippets. //
-
-### // OPTIONAL: Configuration //
-
-// How to further configure the library, list any additional options //
-
-### // OPTIONAL: Specific usage info //
-
-// Depending on the complexity of the library, you might have one or more sections where you explain specific use-cases which do not fall under "basic" usage. You **should not** cover the whole API here, just some of the more common usages of the library. //
+* [Requirements](#requirements)
+* [Getting started](#getting-started)
+* [Usage](#usage)
+* [Contributing](#contributing)
+* [License](#license)
+* [Credits](#credits)
+*
 
 ## Requirements
 
-// e.g., API 21, AndroidX, other libraries //
+<!--
+    Provide information about minimum requirements needed for project to be runnable.
+    e.g., API 21, AndroidX, other libraries //
+-->
+
+## Getting started
+
+<!-- 
+    Explain how to install the project, including any dependencies that need to be installed.
+    Provide clear and concise instructions that can be easily followed.
+    e.g. Groovy and KotlinDSL snippets for including the library (and its modules)
+-->
+
+### Usage
+
+<!--
+    Explain how to use the project, including any relevant code snippets or examples.
+    Provide detailed documentation that explains how to use the project effectively.
+-->
+
+### // OPTIONAL: Configuration //
+
+<!--
+    How to further configure the library, list any additional options
+    If used, don't forget to include in table of contents
+-->
+
+### // OPTIONAL: Specific usage info //
+
+<!--
+    Depending on the complexity of the library, you might have one or more sections where you 
+    explain specific use-cases which do not fall under "basic" usage. You **should not** cover the 
+    whole API here, just some of the more common usages of the library
+    If used, don't forget to include in table of contents
+-->
 
 ### // OPTIONAL // Known issues
 
-// List known issues which are critical to the basic library functions //
+<!--
+    List known issues which are critical to the basic library functions
+    If used, don't forget to include in table of contents
+-->
 
 ## Contributing
 
-Feedback and code contributions are very much welcome. Just make a pull request with a short description of your changes. By making contributions to this project you give permission for your code to be used under the same [license](LICENSE).  
+Feedback and code contributions are very much welcome. Just make a pull request with a short
+description of your changes. By making contributions to this project you give permission for your
+code to be used under the same [license](LICENSE).
 
-// Add any other info specific to contributing to this library (e.g., if you have a sample app to help with development) //
+// Add any other info specific to contributing to this library (e.g., if you have a sample app to
+help with development) //
 
 ## License
 
@@ -61,13 +110,14 @@ limitations under the License.
 ```
 
 ## Credits
-Maintained and sponsored by [Infinum](http://www.infinum.com).
 
-<p align="center">
-  <a href='https://infinum.com'>
+Maintained and sponsored by [Infinum](https://infinum.com).
+
+<div align="center">
+    <a href='https://infinum.com'>
     <picture>
         <source srcset="https://assets.infinum.com/brand/logo/static/white.svg" media="(prefers-color-scheme: dark)">
         <img src="https://assets.infinum.com/brand/logo/static/default.svg">
     </picture>
-  </a>
-</p>
+    </a>
+</div>

--- a/README.md
+++ b/README.md
@@ -35,7 +35,6 @@ Setup instruction: Follow the steps from the SETUP.md file.
 * [Contributing](#contributing)
 * [License](#license)
 * [Credits](#credits)
-*
 
 ## Requirements
 
@@ -52,21 +51,21 @@ Setup instruction: Follow the steps from the SETUP.md file.
     e.g. Groovy and KotlinDSL snippets for including the library (and its modules)
 -->
 
-### Usage
+## Usage
 
 <!--
     Explain how to use the project, including any relevant code snippets or examples.
     Provide detailed documentation that explains how to use the project effectively.
 -->
 
-### // OPTIONAL: Configuration //
+## // OPTIONAL: Configuration //
 
 <!--
     How to further configure the library, list any additional options
     If used, don't forget to include in table of contents
 -->
 
-### // OPTIONAL: Specific usage info //
+## // OPTIONAL: Specific usage info //
 
 <!--
     Depending on the complexity of the library, you might have one or more sections where you 
@@ -75,7 +74,7 @@ Setup instruction: Follow the steps from the SETUP.md file.
     If used, don't forget to include in table of contents
 -->
 
-### // OPTIONAL // Known issues
+## // OPTIONAL // Known issues
 
 <!--
     List known issues which are critical to the basic library functions

--- a/README.md
+++ b/README.md
@@ -74,7 +74,7 @@ Setup instruction: Follow the steps from the SETUP.md file.
     If used, don't forget to include in table of contents
 -->
 
-## // OPTIONAL // Known issues
+## // OPTIONAL Known issues //
 
 <!--
     List known issues which are critical to the basic library functions

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,19 @@
+# Security
+
+## Reporting security issues
+
+At Infinum we are committed to ensuring the security of our software. If you have discovered a security vulnerability or have concerns regarding the security of our project, we encourage you to report it to us in a responsible manner.
+
+If you discover a security vulnerability, please report it to us by emailing us at opensource@infinum.com. We will review your report, and if the issue is confirmed, we will work to resolve the issue as soon as possible and coordinate the release of a security patch.
+
+## Responsible disclosure
+
+We request that you practice responsible disclosure by allowing us time to investigate and address any reported vulnerabilities before making them public. We believe this approach helps protect our users and provides a better outcome for everyone involved.
+
+## Preferred languages
+
+We prefer all communication to be in English.
+
+## Contributions
+
+We greatly appreciate your help in keeping Infinum projects secure. Your efforts contribute to the ongoing improvement of our project's security.

--- a/SETUP.md
+++ b/SETUP.md
@@ -1,0 +1,28 @@
+# Setup instructions
+
+Before you start using this template, complete the following steps:
+
+## Required changes
+
+- [ ] Protect the `main` branch
+- [ ] Add a short description of the repository
+- [ ] Add tags for the repository
+  - [ ] `open-source`,
+  - [ ] technology tag (`android`, `ios`, or `flutter`),
+  - [ ] other tags that are relevant to the repository
+- [ ] Create a `.gitignore` file
+- [ ] Create workflows
+- [ ] Update the `README.md` file with the missing information
+  - [ ] Delete the _Setup instructions_ note from the file
+  - [ ] Add the project name
+  - [ ] Add the missing information based on the comments in the file
+- [ ] Delete the `SETUP.md` file
+  
+## Optional changes
+
+- [ ] Update the `CODE_OF_CONDUCT.md` file
+- [ ] Update the `CONTRIBUTING.md` file
+- [ ] Update the `SECURITY.md` file
+- [ ] Update the `LICENSE` file
+- [ ] Update the pull request template
+- [ ] Update issue templates

--- a/SETUP.md
+++ b/SETUP.md
@@ -8,10 +8,8 @@ Before you start using this template, complete the following steps:
 - [ ] Add a short description of the repository
 - [ ] Add tags for the repository
   - [ ] `open-source`,
-  - [ ] technology tag (`android`, `ios`, or `flutter`),
+  - [ ] technology tag (`android` in this case),
   - [ ] other tags that are relevant to the repository
-- [ ] Create a `.gitignore` file
-- [ ] Create workflows
 - [ ] Update the `README.md` file with the missing information
   - [ ] Delete the _Setup instructions_ note from the file
   - [ ] Add the project name
@@ -24,5 +22,6 @@ Before you start using this template, complete the following steps:
 - [ ] Update the `CONTRIBUTING.md` file
 - [ ] Update the `SECURITY.md` file
 - [ ] Update the `LICENSE` file
+- [ ] Update the `.gitignore` file
 - [ ] Update the pull request template
 - [ ] Update issue templates


### PR DESCRIPTION
## :page_facing_up: Context
Aligning template with [open source template](https://github.com/infinum/open-source-mobile-template)

## :pencil: Changes

- Update Github templates for PR, bug report and feature reports. I removed icons from text, now templates looks more like open source ones
- Add markdown files for security, setup, code of conduct, contribution
- Update Readme

If you see anything specific to Android lib template that you think we should add/return, please inform me
