### PR TITLE
Replace personal publishing info with Infinum's info

### DIFF
--- a/maven-publish.gradle
+++ b/maven-publish.gradle
@@ -59,12 +59,15 @@ afterEvaluate {
                             url = 'http://www.apache.org/licenses/LICENSE-2.0.txt'
                         }
                     }
+                    organization {
+                        name = 'Infinum Inc.'
+                        url = 'https://infinum.com'
+                    }
                     developers {
-                        // TODO - update with correct developer id
                         developer {
-                            id = 'malicombo'
-                            name = 'Mali Čombo'
-                            email = 'mali.combo@infinum.com'
+                            id = 'Infinum'
+                            name = 'Infinum Inc.'
+                            url = 'https://infinum.com'
                         }
                     }
                     scm {


### PR DESCRIPTION
## Summary

Publishing info should reflect that Infinum is developer/maintainer of library. That info is shown when fetching licences with tools like: https://github.com/mikepenz/AboutLibraries

## Changes

In `maven-publish.gradle` personal info has been replaced with Infinum's info

### Type

- [ ] **Feature**: This pull request introduces a new feature.
- [ ] **Bug fix**: This pull request fixes a bug.
- [ ] **Refactor**: This pull request refactors existing code.
- [ ] **Documentation**: This pull request updates documentation.
- [x] **Other**: This pull request makes other changes.

#### Additional information

- [ ] This pull request introduces a **breaking change**.

### Description

<!-- 
    Describe the specific changes made in this pull request, including any technical details or architectural decisions. 

    If applicable, include additional information like screenshots, logs or other data that demonstrate the changes. 
-->

## Checklist

- [x] I have performed a self-review of my own code.
- [x] I have tested my changes, including edge cases.
- [ ] I have added necessary tests for the changes introduced (if applicable).
- [ ] I have updated the documentation to reflect my changes (if applicable).

## Additional notes

<!-- 
    Add any additional comments, instructions, or insights about this pull request. 
-->
